### PR TITLE
Create dondurma-rss-reader.yml for project setup

### DIFF
--- a/data/records/dondurma-rss-reader.yml
+++ b/data/records/dondurma-rss-reader.yml
@@ -1,0 +1,39 @@
+kind: project
+slug: dondurma-rss-reader
+name: "Dondurma - Rss & News Reader"
+description: "🍦 A premium, open-source RSS/Atom feed reader built with Flutter and Material 3. Cross-platform, private, and algorithm-free."
+category: news
+projectType: real-app
+stack: "flutter"
+platforms:
+  - ios
+  - android
+tags:
+  - adblocker
+  - android
+  - atom
+  - cross-platform
+  - dart
+  - desktop
+  - desktop-app
+  - feed-reader
+licenses:
+  - mit
+repoUrl: https://github.com/DevOpen-io/dondurma-rss-reader
+links:
+  github: https://github.com/DevOpen-io/dondurma-rss-reader
+  website: https://dondurma.devopen.io/
+bestFor:
+  - Reading RSS and Atom feeds
+  - Following blogs and news sources
+  - Offline article reading
+  - Privacy-focused news consumption
+  - Cross-platform RSS reading
+source:
+  type: manual
+  owner: DevOpen-io
+  repo: dondurma-rss-reader
+curation:
+  reviewed: false
+  labels: []
+  lenses: []


### PR DESCRIPTION
## What this PR does

Adds **Dondurma RSS Reader** to the Open Apps directory with its project metadata, tags, supported platforms, license, website, and recommended use cases.

Dondurma is an open-source, cross-platform RSS/Atom feed reader built with **Flutter and Dart**.

## Why

Dondurma provides a privacy-focused RSS reading experience with features including:

- RSS and Atom feed support
- Offline article reading
- Full-text article extraction
- OPML import/export
- Feed organization with categories
- Background synchronization
- New article notifications
- Cross-platform support

Repository: https://github.com/DevOpen-io/dondurma-rss-reader

Website: https://dondurma.devopen.io/

## How to verify

1. Run `pnpm install`
2. Run `pnpm exec grove validate`
3. Run `pnpm grove:dev`
4. Open the local Open Apps website
5. Search for **Dondurma RSS Reader**
6. Confirm that the project metadata is displayed correctly
7. Confirm that Flutter/Dart, supported platforms, MIT license, tags, website, and "Best for" entries are shown correctly

## Checklist

- [ ] `pnpm exec grove validate` passes
- [ ] `pnpm run build` succeeds locally
- [ ] The Dondurma RSS Reader record has a unique `slug`
- [ ] The `slug` matches the filename in `data/records/<slug>.yml`
- [ ] Existing categories, stacks, and platforms are used correctly
- [ ] Project metadata and links are correct

## Disclosure

I am the maintainer of **Dondurma RSS Reader**.