### PR TITLE
feat(records): add Tracexy

### DIFF
--- a/data/health.yml
+++ b/data/health.yml
@@ -10634,3 +10634,13 @@ health:
     confidence: medium
     reasons:
     - active-development
+- id: tracexy
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development

--- a/data/records/tracexy.yml
+++ b/data/records/tracexy.yml
@@ -1,0 +1,49 @@
+kind: project
+slug: tracexy
+name: "Tracexy"
+description: "A native, local-first macOS app for capturing live network traffic and investigating PCAP and PCAPNG files."
+sourceDescription: "Native, local-first network intelligence for macOS—capture live traffic, inspect PCAP/PCAPNG files, and investigate sessions, protocols, processes, flows, and packet evidence."
+category: developer-tools
+projectType: real-app
+stack: ios
+platforms:
+  - macos
+tags:
+  - libpcap
+  - network-analysis
+  - network-monitoring
+  - packet-capture
+  - pcap
+  - pcapng
+  - privacy
+  - security
+licenses:
+  - agpl-3.0
+repoUrl: https://github.com/RockxyApp/Tracexy
+links:
+  github: https://github.com/RockxyApp/Tracexy
+  website: https://rockxy.io/tracexy
+distribution:
+  channels:
+    - type: github-releases
+      label: GitHub Releases
+      url: https://github.com/RockxyApp/Tracexy/releases
+      verified: false
+bestFor:
+  - Capturing and investigating network traffic locally on macOS
+  - Reviewing PCAP and PCAPNG files without uploading capture data
+whyListed:
+  - Provides a native Swift codebase for studying packet capture, protocol decoding, and session analysis.
+caveats:
+  - Requires macOS 14 or later.
+source:
+  type: submit
+  provider: github
+  owner: RockxyApp
+  repo: Tracexy
+  url: https://github.com/RockxyApp/Tracexy
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep


### PR DESCRIPTION
## What this PR does

Adds Tracexy as a native macOS network intelligence app in the Developer Tools category. The record includes its canonical source, website, GitHub Releases channel, platform, stack, license, focused tags, use cases, and macOS requirement.

## Why

Tracexy is useful for capturing live traffic and investigating PCAP or PCAPNG files locally. Its public Swift codebase also provides a practical reference for packet capture, protocol decoding, and session-oriented network analysis.

## How to verify

1. Run `pnpm install --frozen-lockfile`.
2. Run `pnpm exec grove icons sync --check`.
3. Run `pnpm exec grove check`.
4. Run `pnpm build`.
5. Open `/apps/tracexy/` and confirm the app metadata and links.

## Checklist

- [x] `pnpm exec grove check` passes with only the existing `BeeCount` filename warning.
- [x] `pnpm build` succeeds locally.
- [x] The `tracexy` slug is unique and matches `data/records/tracexy.yml`.
- [x] Existing category, stack, platform, license, and distribution taxonomy values are reused.

`data/health.yml` receives only the minimal matching health entry required by the current Grove `missing_health` validation; no generated Open Graph images or unrelated sync output are included.