### PR TITLE
feat(records): add Rockxy

### DIFF
--- a/data/health.yml
+++ b/data/health.yml
@@ -10634,3 +10634,13 @@ health:
     confidence: medium
     reasons:
     - active-development
+- id: rockxy
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development

--- a/data/records/rockxy.yml
+++ b/data/records/rockxy.yml
@@ -1,0 +1,49 @@
+kind: project
+slug: rockxy
+name: "Rockxy"
+description: "A native macOS HTTP debugging proxy for inspecting HTTPS, API, WebSocket, and GraphQL traffic."
+sourceDescription: "Open-source native macOS HTTP debugging proxy — intercept HTTPS, inspect APIs, mock responses, debug WebSocket & GraphQL. Community-driven. For developers, by developers."
+category: developer-tools
+projectType: real-app
+stack: ios
+platforms:
+  - macos
+tags:
+  - api-debugging
+  - graphql
+  - http-proxy
+  - https-inspection
+  - mock-api
+  - network-debugging
+  - websocket
+licenses:
+  - agpl-3.0
+repoUrl: https://github.com/RockxyApp/Rockxy
+links:
+  github: https://github.com/RockxyApp/Rockxy
+  website: https://rockxy.io
+distribution:
+  channels:
+    - type: github-releases
+      label: GitHub Releases
+      url: https://github.com/RockxyApp/Rockxy/releases
+      verified: false
+bestFor:
+  - Debugging HTTP and HTTPS traffic during macOS and iOS development
+  - Inspecting API, WebSocket, and GraphQL exchanges
+whyListed:
+  - Demonstrates a native Swift proxy with traffic interception, inspection, and response mocking.
+caveats:
+  - HTTPS inspection requires installing and trusting a local root certificate.
+  - Source code is AGPL-3.0, while official signed downloads use a separate binary EULA.
+source:
+  type: submit
+  provider: github
+  owner: RockxyApp
+  repo: Rockxy
+  url: https://github.com/RockxyApp/Rockxy
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep


### PR DESCRIPTION
## What this PR does

Adds Rockxy as a native macOS HTTP debugging proxy in the Developer Tools category. The record includes its canonical source, website, GitHub Releases channel, platform, stack, license, focused protocol tags, use cases, and relevant certificate and binary-license caveats.

## Why

Rockxy is useful for debugging HTTP and HTTPS traffic and inspecting API, WebSocket, and GraphQL exchanges. Its public Swift codebase is also a practical reference for native proxying, traffic inspection, certificate handling, and response mocking.

## How to verify

1. Run `pnpm install --frozen-lockfile`.
2. Run `pnpm exec grove icons sync --check`.
3. Run `pnpm exec grove check`.
4. Run `pnpm build`.
5. Open `/apps/rockxy/` and confirm the app metadata, caveats, and links.

## Checklist

- [x] `pnpm exec grove check` passes with only the existing `BeeCount` filename warning.
- [x] `pnpm build` succeeds locally.
- [x] The `rockxy` slug is unique and matches `data/records/rockxy.yml`.
- [x] Existing category, stack, platform, license, and distribution taxonomy values are reused.

`data/health.yml` receives only the minimal matching health entry required by the current Grove `missing_health` validation; no generated Open Graph images or unrelated sync output are included.