### PR TITLE
feat(records): add Shieldxy

### DIFF
--- a/data/health.yml
+++ b/data/health.yml
@@ -10634,3 +10634,13 @@ health:
     confidence: medium
     reasons:
     - active-development
+- id: shieldxy
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development

--- a/data/records/shieldxy.yml
+++ b/data/records/shieldxy.yml
@@ -1,0 +1,47 @@
+kind: project
+slug: shieldxy
+name: "Shieldxy"
+description: "An auditable macOS application firewall and connection monitor with explicit local network controls."
+sourceDescription: "Open-source, auditable application firewall and connection monitor for macOS."
+category: tools
+projectType: real-app
+stack: ios
+platforms:
+  - macos
+tags:
+  - application-firewall
+  - network-monitoring
+  - network-security
+  - privacy
+  - security
+licenses:
+  - agpl-3.0
+repoUrl: https://github.com/RockxyApp/Shieldxy
+links:
+  github: https://github.com/RockxyApp/Shieldxy
+  website: https://rockxy.io/shieldxy
+distribution:
+  channels:
+    - type: github-releases
+      label: GitHub Releases
+      url: https://github.com/RockxyApp/Shieldxy/releases
+      verified: false
+bestFor:
+  - Monitoring outbound connections by application
+  - Managing explicit application and domain firewall rules
+whyListed:
+  - Shows an auditable Swift implementation of a macOS Network Extension firewall and local policy engine.
+caveats:
+  - Requires macOS 14 or later.
+  - Development builds of the installed network filter require a paid Apple Developer account.
+source:
+  type: submit
+  provider: github
+  owner: RockxyApp
+  repo: Shieldxy
+  url: https://github.com/RockxyApp/Shieldxy
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep


### PR DESCRIPTION
## What this PR does

Adds Shieldxy as an auditable macOS application firewall and connection monitor in the Tools category. The record includes its canonical source, website, GitHub Releases channel, platform, stack, license, security-focused tags, use cases, and relevant macOS and development-signing requirements.

## Why

Shieldxy is useful for monitoring outbound connections and managing explicit application and domain firewall rules. Its public Swift codebase provides a practical reference for a macOS Network Extension firewall, application identity, and local policy enforcement.

## How to verify

1. Run `pnpm install --frozen-lockfile`.
2. Run `pnpm exec grove icons sync --check`.
3. Run `pnpm exec grove check`.
4. Run `pnpm build`.
5. Open `/apps/shieldxy/` and confirm the app metadata, caveats, and links.

## Checklist

- [x] `pnpm exec grove check` passes with only the existing `BeeCount` filename warning.
- [x] `pnpm build` succeeds locally.
- [x] The `shieldxy` slug is unique and matches `data/records/shieldxy.yml`.
- [x] Existing category, stack, platform, license, and distribution taxonomy values are reused.

`data/health.yml` receives only the minimal matching health entry required by the current Grove `missing_health` validation; no generated Open Graph images or unrelated sync output are included.