### PR TITLE
Add Loofah to Open Apps

### DIFF
--- a/data/health.yml
+++ b/data/health.yml
@@ -10686,6 +10686,25 @@ health:
     monthlyCommits:
     - month: 2026-08
       commits: 0
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development
+- id: loofah
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development
 - id: shieldxy
   health:
     status: active

--- a/data/records/loofah.yml
+++ b/data/records/loofah.yml
@@ -1,0 +1,57 @@
+kind: project
+name: Loofah
+slug: loofah
+description: Loofah is an MIT-licensed, local-first meeting notetaker for macOS that records and transcribes on-device and stores notes as ordinary Markdown.
+summary: A Tauri/Rust desktop app and CLI with no account, backend, telemetry, or required cloud; optional summaries use the user's chosen LLM, and a read-only local MCP server exposes the vault to agents.
+sourceDescription: Free, open-source meeting notes for macOS with private on-device transcription, Markdown storage, and optional bring-your-own AI—no accounts, subscriptions, or telemetry.
+category: productivity
+tags:
+  - open-source
+  - offline-first
+  - desktop-app
+  - productivity
+  - privacy
+  - notes
+  - cli
+stack: tauri
+platforms:
+  - macos
+  - desktop
+projectType: real-app
+repoUrl: https://github.com/bart6114/loofah
+links:
+  github: https://github.com/bart6114/loofah
+  website: https://loofah.io
+licenses:
+  - mit
+distribution:
+  channels:
+    - type: github-releases
+      platform: macos
+      label: GitHub Releases
+      url: https://github.com/bart6114/loofah/releases/latest
+      verified: true
+    - type: website
+      platform: macos
+      label: Loofah website
+      url: https://loofah.io
+      verified: true
+bestFor:
+  - Keeping meeting recordings, transcripts, notes, research, and agent-created artifacts in one local Markdown vault.
+  - People who want on-device meeting transcription without adding a bot to calls.
+whyListed:
+  - The complete MIT-licensed application is available to run, inspect, and study.
+  - The codebase combines a Tauri desktop app, Rust CLI, local transcription, Markdown storage, and read-only MCP access.
+caveats:
+  - The desktop app currently requires an Apple Silicon Mac; the CLI also supports Linux.
+source:
+  type: import
+  provider: github
+  owner: bart6114
+  repo: loofah
+  url: https://github.com/bart6114/loofah
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep


### PR DESCRIPTION
## What this PR does

Adds a curated Loofah record under Productivity with its Tauri stack, macOS platform, MIT license, release links, and factual project notes.

## Why

Loofah is a usable open-source application rather than a library or demo. Its codebase combines a Tauri desktop app, Rust CLI, local transcription, Markdown storage, and read-only MCP access. The repository has public releases, documentation, tests, and a clear MIT license.

Affiliation: I'm the Loofah maintainer. This PR was prepared with an automated agent.

## How to verify

1. `pnpm install`
2. `pnpm exec grove check` (currently reports the same pre-existing `data/health.yml` and missing-health errors on unchanged `main`; the Loofah branch adds no distinct schema error)
3. `pnpm build`
4. Open `/apps/loofah/` and confirm the record renders under Productivity and Tauri

## Checklist

- [ ] `pnpm exec grove check` passes (blocked by the current upstream health-data baseline)
- [x] `pnpm run build` succeeds locally
- [x] The `loofah` slug is unique and matches `data/records/loofah.yml`
- [x] The record uses existing Productivity, Tauri, macOS, desktop, and MIT taxonomy values

Exact new YAML record:

```yaml
kind: project
name: Loofah
slug: loofah
description: Loofah is an MIT-licensed, local-first meeting notetaker for macOS that records and transcribes on-device and stores notes as ordinary Markdown.
summary: A Tauri/Rust desktop app and CLI with no account, backend, telemetry, or required cloud; optional summaries use the user's chosen LLM, and a read-only local MCP server exposes the vault to agents.
sourceDescription: Free, open-source meeting notes for macOS with private on-device transcription, Markdown storage, and optional bring-your-own AI—no accounts, subscriptions, or telemetry.
category: productivity
tags: [open-source, offline-first, desktop-app, productivity, privacy, notes, cli]
stack: tauri
platforms: [macos, desktop]
projectType: real-app
repoUrl: https://github.com/bart6114/loofah
links: {github: https://github.com/bart6114/loofah, website: https://loofah.io}
licenses: [mit]
distribution:
  channels:
    - {type: github-releases, platform: macos, label: GitHub Releases, url: https://github.com/bart6114/loofah/releases/latest, verified: true}
    - {type: website, platform: macos, label: Loofah website, url: https://loofah.io, verified: true}
bestFor:
  - Keeping meeting recordings, transcripts, notes, research, and agent-created artifacts in one local Markdown vault.
  - People who want on-device meeting transcription without adding a bot to calls.
whyListed:
  - The complete MIT-licensed application is available to run, inspect, and study.
  - The codebase combines a Tauri desktop app, Rust CLI, local transcription, Markdown storage, and read-only MCP access.
caveats:
  - The desktop app currently requires an Apple Silicon Mac; the CLI also supports Linux.
source: {type: import, provider: github, owner: bart6114, repo: loofah, url: https://github.com/bart6114/loofah}
curation: {reviewed: false, labels: [], lenses: []}
visibility: keep
```
