### PR TITLE
feat(records): add d1v.ai mobile

### DIFF
--- a/data/records/d1vai-app.yml
+++ b/data/records/d1vai-app.yml
@@ -1,0 +1,47 @@
+kind: project
+slug: d1vai-app
+name: d1v.ai Mobile
+description: A Flutter mobile workspace for creating or importing projects, continuing AI-assisted
+  work, inspecting files, and monitoring preview and deployment state from iOS or Android.
+sourceDescription: Official Flutter client for d1v.ai, an AI-native mobile workspace for builders,
+  operators, and modern product teams.
+category: developer-tools
+projectType: real-app
+stack: flutter
+platforms:
+  - ios
+  - android
+tags:
+  - mobile-app
+  - developer-tools
+  - open-source
+licenses:
+  - mit
+repoUrl: https://github.com/d1vai/d1vai_app
+links:
+  github: https://github.com/d1vai/d1vai_app
+  website: https://www.d1v.ai
+distribution:
+  channels:
+    - type: github-releases
+      label: GitHub Releases
+      url: https://github.com/d1vai/d1vai_app/releases
+      verified: false
+bestFor:
+  - Studying a production Flutter client for AI-assisted project workflows
+  - Monitoring remote project, preview, and deployment state from a phone
+whyListed:
+  - Demonstrates mobile-native project creation, repository import, AI session continuity, and operational visibility in one open-source Flutter app.
+caveats:
+  - The documented product platforms are iOS and Android; this entry does not claim desktop support.
+source:
+  type: submit
+  provider: github
+  owner: d1vai
+  repo: d1vai_app
+  url: https://github.com/d1vai/d1vai_app
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep


### PR DESCRIPTION
## What this PR does

Adds `d1v.ai Mobile` as a real, open-source Flutter application in the Developer Tools category.

- [x] Adds a new app (`data/records/d1vai-app.yml`)
- [ ] Updates an existing app
- [ ] Fixes a bug in scripts or the build pipeline
- [ ] Updates docs / metadata (README, CONTRIBUTING, etc.)

## New app details

- **Repo URL**: https://github.com/d1vai/d1vai_app
- **Category**: Developer Tools
- **Primary stack**: Flutter
- **Platforms**: iOS, Android
- **License**: MIT
- **One-line description**: A Flutter mobile workspace for creating or importing projects, continuing AI-assisted work, inspecting files, and monitoring preview and deployment state from iOS or Android.
- **Website**: https://www.d1v.ai

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] The entry is a usable application rather than a library, tutorial, boilerplate, or marketing-only page.
- [x] The application has a public source repository and a verifiable MIT license.
- [x] I did not edit automation-owned health metadata or generated artifacts.
- [x] The file is `data/records/d1vai-app.yml` and its slug is `d1vai-app`.

## Validation

- `git diff --check`: passed.
- `pnpm build`: passed; it generated the `/apps/d1vai-app/` page.
- `pnpm exec grove check`: blocked by the current upstream `data/health.yml` baseline. It reports `health_file_invalid` followed by missing-health errors for existing records, before considering this record; I left that automation-owned file unchanged as requested by the contributor guide.

I am affiliated with d1v.ai. I used AI assistance to read the repository rules, verify duplicate state and documented product claims, draft the minimal metadata record, and run the listed checks; I reviewed the final change.