### PR TITLE
fix: restore Grove validation after d1v.ai merge

### DIFF
--- a/data/health.yml
+++ b/data/health.yml
@@ -10464,6 +10464,16 @@ health:
     confidence: medium
     reasons:
     - active-development
+- id: d1vai-app
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development
 - id: habo
   github:
     fullName: xpavle00/Habo

--- a/data/records/beecount.yml
+++ b/data/records/beecount.yml
@@ -1,6 +1,6 @@
 kind: project
 name: BeeCount
-slug: BeeCount
+slug: beecount
 description: BeeCount is a Flutter-based local-first bookkeeping app for iOS, Android, and Web that
   offers five interchangeable sync backends (the self-hosted BeeCount Cloud, iCloud, Supabase,
   WebDAV, and any S3-compatible store), AI-assisted capture via a dual on-device/cloud OCR pipeline,


### PR DESCRIPTION
## Summary
- add the required health snapshot for the merged d1vai-app record
- normalize the existing beecount record slug to match its filename

## Validation
- pnpm exec grove check
- pnpm build

This uses the same minimal health-entry pattern as #227 and addresses the two findings from the post-merge CI run #33340731501.