### PR TITLE
Add Authier to Open Apps

### DIFF
--- a/content/records/authier.md
+++ b/content/records/authier.md
@@ -1,0 +1,29 @@
+# Authier
+
+Authier is an open-source password manager for login credentials and time-based one-time password (TOTP) secrets. Its public user-facing clients are a web vault and extensions for Chrome, Firefox, and Microsoft Edge; the Firefox extension also runs on Firefox for Android.
+
+## What the codebase includes
+
+- A React browser extension with Manifest V2 and Manifest V3 builds, vault management, password autofill, and TOTP support.
+- A separate React web vault for viewing and editing credentials, TOTP records, devices, and account settings.
+- A React Native mobile client in the monorepo, although native mobile builds are not currently listed as supported public downloads.
+- An Elysia API deployed through a Cloudflare Worker adapter, plus shared TypeScript schemas and cryptographic code used across clients.
+- An Astro marketing and documentation site that publishes the current security model, download routes, privacy policy, and practical security caveats.
+
+## Security model in the repository
+
+Authier derives the client encryption key from the master password and a per-account salt using PBKDF2 with SHA-512 and 600,000 iterations. Vault items are encrypted with AES-256-GCM and a fresh initialization vector before synchronization, so the API receives encrypted credential and TOTP payloads rather than those secrets in plaintext.
+
+Accounts can be configured to require approval from an existing trusted device before a new client enrolls and begins vault synchronization. TOTP synchronization can also be disabled per device. These controls are useful code to inspect, but they do not remove the need to protect every unlocked client and keep independent recovery options.
+
+## Why it is useful to study
+
+The repository shows how one TypeScript monorepo coordinates browser-extension, web, React Native, API, schema-generation, and encryption concerns for a security-sensitive product. It also exposes the practical edges that simpler examples often omit: multi-step-login autofill, device enrollment, encrypted synchronization, TOTP import/export, and separate Manifest V2 and V3 builds.
+
+The [security architecture](https://www.authier.pm/security) documents the intended cryptographic flow, while the [official download page](https://www.authier.pm/download) identifies the currently supported clients.
+
+## Caveats
+
+Authier is a young, experimental password manager and has not published an independent third-party security audit. Public source makes the implementation inspectable, but it is not a substitute for a professional audit, a long operating history, or broad real-world review. For important secrets, an established audited password manager is the more conservative default.
+
+The native mobile clients remain source code rather than a current supported store release, and the project does not currently document self-hosting as a supported deployment route. Evaluate the repository and its limitations before using it beyond a low-risk test vault.

--- a/data/health.yml
+++ b/data/health.yml
@@ -347,6 +347,16 @@ health:
     cleanupCandidate: false
     confidence: medium
     reasons: []
+- id: authier
+  health:
+    status: active
+    maturity: unknown
+    tier: listed
+    visibility: keep
+    cleanupCandidate: false
+    confidence: medium
+    reasons:
+    - active-development
 - id: apprtc-ios
   github:
     fullName: ISBX/apprtc-ios

--- a/data/records/authier.yml
+++ b/data/records/authier.yml
@@ -1,0 +1,72 @@
+kind: project
+name: Authier
+slug: authier
+description: Authier is an experimental AGPL password manager monorepo with a React Native client, browser extensions, and a web vault for credentials and TOTP codes.
+summary: A TypeScript codebase spanning React Native, browser-extension, Astro, and Cloudflare Worker clients, built around client-side encrypted vault sync and optional trusted-device enrollment approval.
+sourceDescription: monorepo for Authier password manager
+category: productivity
+tags:
+  - open-source
+  - mobile-app
+  - web-app
+  - productivity
+  - privacy
+  - security
+  - encryption
+  - sync
+stack: react-native
+platforms:
+  - ios
+  - android
+  - web
+projectType: real-app
+repoUrl: https://github.com/authier-pm/authier
+links:
+  github: https://github.com/authier-pm/authier
+  website: https://www.authier.pm/
+licenses:
+  - agpl-3.0
+distribution:
+  channels:
+    - type: website
+      platform: web
+      label: Web vault and downloads
+      url: https://www.authier.pm/download
+      verified: true
+    - type: other
+      platform: web
+      label: Chrome Web Store
+      url: https://chromewebstore.google.com/detail/authier/padmmdghcflnaellmmckicifafoenfdi
+      verified: true
+    - type: other
+      platform: web
+      label: Firefox Add-ons
+      url: https://addons.mozilla.org/en-US/firefox/addon/authier/
+      verified: true
+    - type: other
+      platform: web
+      label: Microsoft Edge Add-ons
+      url: https://microsoftedge.microsoft.com/addons/detail/authier/jahkkkffomngonmmoopccjnhlngjjnll
+      verified: true
+bestFor:
+  - Studying a full-stack TypeScript password manager across React Native, browser extensions, a web vault, and an edge-hosted API.
+  - Exploring client-side encrypted synchronization, TOTP handling, autofill, and trusted-device enrollment workflows in an early-stage codebase.
+whyListed:
+  - The complete AGPL-licensed application stack is public, actively maintained, documented, and available through three browser-extension stores plus a web vault.
+  - The monorepo provides a concrete example of sharing password-manager schemas and cryptographic workflows across several TypeScript clients.
+caveats:
+  - Authier is early-stage and has not published an independent third-party security audit; an established audited password manager is the safer default for important secrets.
+  - The native React Native clients are present in source but are not a current public download path; supported downloads are the web vault and browser extensions, including Firefox for Android.
+  - The repository is inspectable, but the current documentation does not present self-hosting as a supported deployment path.
+source:
+  type: submit
+  provider: github
+  owner: authier-pm
+  repo: authier
+  url: https://github.com/authier-pm/authier
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep
+content: ./content/records/authier.md


### PR DESCRIPTION
## What this PR does

Adds Authier as a Productivity / React Native record, with verified browser-extension distribution links, a canonical homepage, a concise health entry, and long-form notes covering the codebase and its current limitations.

## Why

Authier is a usable AGPL application rather than a library or demo. Its public clients include a web vault and extensions in the Chrome, Firefox, and Microsoft Edge stores. The monorepo is also useful to study because it spans React Native, browser-extension, web, Astro, Elysia/Cloudflare Worker, shared-schema, and client-side cryptography concerns.

The record deliberately identifies Authier as early-stage, notes that it has no published independent third-party security audit, says an established audited password manager is the safer default for important secrets, and distinguishes the source-only native clients from the supported public downloads.

Affiliation: I maintain Authier. I used AI assistance to inspect the repository rules and implementation evidence, draft the record and notes, run the checks, and review the rendered page; I manually reviewed the final contribution.

## How to verify

1. `pnpm install`
2. `pnpm exec grove icons sync --check`
3. `pnpm exec grove check`
4. `pnpm run build`
5. Open `/apps/authier/` and confirm that the long-form notes, caveats, taxonomy, distribution links, and canonical Homepage control render correctly.

## Validation

- Icon drift check: passed.
- Grove check: passed with 0 errors (only seven pre-existing TypeScript hints).
- Production build: passed; 142 pages generated, including `/apps/authier/`.
- Rendered page reviewed in the browser; the Homepage control resolves to `https://www.authier.pm/` without `nofollow`.

## Checklist

- [x] `pnpm exec grove check` passes
- [x] `pnpm run build` succeeds locally
- [x] The `authier` slug is unique and matches `data/records/authier.yml`
- [x] The record uses existing Productivity, React Native, iOS, Android, Web, AGPL, and topic taxonomy values
- [x] The public repository, license, store listings, security documentation, and deployment caveats were verified