### PR TITLE
Add Posnic POS

### DIFF
--- a/content/records/posnic-pos.md
+++ b/content/records/posnic-pos.md
@@ -1,0 +1,48 @@
+# Posnic POS
+
+Posnic POS is a desktop point-of-sale and billing app for retail shops and restaurants. The local edition runs the till and its database on hardware the shop controls, while the public source also includes setup, support, update, backup, and optional cloud-activation surfaces around that local workflow.
+
+## What the codebase includes
+
+- An Electron desktop shell with a local Node.js API and a MongoDB-backed data store.
+- Checkout and billing flows for sales, returns, held bills, part payments, receipts, and reports.
+- Inventory and purchasing screens for item stock, suppliers, purchase entries, and stock-aware selling.
+- Restaurant-oriented support such as kitchen order ticket handling and receipt printer integration.
+- Backup, restore, update, startup, hardware, and log-management surfaces that are part of the packaged desktop app rather than separate examples.
+- Release packaging for Windows, macOS, and Linux through GitHub Releases.
+
+## Why it is useful to study
+
+Open-source POS codebases are often narrow web demos or inventory samples. Posnic is useful because it shows the messier desktop concerns that real shop software has to handle: local database startup, first-run setup, retail hardware, offline checkout, update safety, backup safety, receipts, and support context.
+
+The repository also keeps operational documents next to the code. The README, self-hosting notes, hardware matrix, privacy page, governance policy, release verification guide, and third-party notices make it possible to review both the application behavior and the packaging boundary.
+
+## Caveats
+
+Posnic-owned source is AGPL-3.0-only. Release packages include separately licensed components, including MongoDB Community Server under SSPL-1.0, so downstream packagers should read the third-party notices and package evidence before redistributing binaries.
+
+Windows is the best-tested retail-hardware target. macOS and Linux builds are published, but hardware validation is thinner there. Operators should also expect normal first-launch trust warnings while signing and notarization mature.
+
+The project is young and low-star. Treat it as a codebase worth inspecting, not as a popularity signal.
+
+## How to run it
+
+```bash
+git clone https://github.com/Posnic/POS
+cd POS
+npm install
+npm start
+```
+
+The development app downloads and runs its local database during setup. For packaged users, the current downloads live on the v1.6.1 GitHub release.
+
+## Verified sources
+
+- Posnic POS repository: <https://github.com/Posnic/POS>
+- Posnic website: <https://posnic.io/>
+- Latest release: <https://github.com/Posnic/POS/releases/tag/v1.6.1>
+- User guide: <https://github.com/Posnic/POS/blob/develop/docs/USER_GUIDE.md>
+- Self-hosting guide: <https://github.com/Posnic/POS/blob/develop/docs/SELF_HOSTING.md>
+- Hardware matrix: <https://github.com/Posnic/POS/blob/develop/docs/HARDWARE_MATRIX.md>
+- Release verification: <https://github.com/Posnic/POS/blob/develop/docs/VERIFY_RELEASE.md>
+- Third-party notices: <https://github.com/Posnic/POS/blob/develop/THIRD-PARTY-NOTICES.md>

--- a/data/health.yml
+++ b/data/health.yml
@@ -4045,3 +4045,13 @@ health:
       confidence: medium
       reasons:
         - active-development
+  - id: posnic-pos
+    health:
+      status: active
+      maturity: unknown
+      tier: listed
+      visibility: keep
+      cleanupCandidate: false
+      confidence: medium
+      reasons:
+        - active-development

--- a/data/records/posnic-pos.yml
+++ b/data/records/posnic-pos.yml
@@ -1,0 +1,78 @@
+kind: project
+name: Posnic POS
+slug: posnic-pos
+description: Posnic POS is offline-first open-source POS and billing software for retail shops and restaurants, built as a JavaScript/Electron desktop app with a local MongoDB-backed checkout.
+summary: A cross-platform JavaScript/Electron point-of-sale app for retail shops and restaurants, with billing, inventory, purchases, reports, receipt printing, local backups, and optional online/offline workflows around a local MongoDB-backed till.
+sourceDescription: Free offline-first open source POS and billing software for retail and restaurants. AGPL-3.0-only source; packages include separately licensed components.
+content: ./content/records/posnic-pos.md
+category: business
+tags:
+  - open-source
+  - desktop-app
+  - offline-first
+  - self-hosted
+  - point-of-sale
+  - pos-system
+  - billing-software
+  - inventory-management
+  - restaurant
+  - retail
+  - electron
+  - mongodb
+  - windows
+  - macos
+  - linux
+stack: javascript
+platforms:
+  - windows
+  - macos
+  - linux
+projectType: real-app
+repoUrl: https://github.com/Posnic/POS
+links:
+  github: https://github.com/Posnic/POS
+  website: https://posnic.io/
+  docs: https://github.com/Posnic/POS/tree/develop/docs
+licenses:
+  - agpl-3.0
+distribution:
+  channels:
+    - type: github-releases
+      platform: windows
+      label: Windows installer
+      url: https://github.com/Posnic/POS/releases/tag/v1.6.1
+      verified: true
+    - type: github-releases
+      platform: macos
+      label: macOS package
+      url: https://github.com/Posnic/POS/releases/tag/v1.6.1
+      verified: true
+    - type: github-releases
+      platform: linux
+      label: Linux AppImage and Debian package
+      url: https://github.com/Posnic/POS/releases/tag/v1.6.1
+      verified: true
+bestFor:
+  - Studying an offline-first POS and billing desktop app that keeps checkout usable with a local database.
+  - Comparing retail and restaurant workflows such as sales, purchases, inventory, receipt printing, backups, and reports.
+  - Running or adapting a small-business POS where the application source, releases, and operating docs are public.
+whyListed:
+  - It is a complete application rather than a library, template, or one-screen demo, with public release assets for Windows, macOS, and Linux.
+  - The codebase shows how an Electron desktop shell, a local API, and a bundled MongoDB service can be packaged for point-of-sale use.
+  - The project documents installation, self-hosting, hardware expectations, release verification, privacy, governance, and third-party package licensing.
+caveats:
+  - Posnic-owned source is AGPL-3.0-only, while release packages bundle separately licensed components including MongoDB Community Server under SSPL-1.0.
+  - Windows is the best-tested retail-hardware target; macOS and Linux builds are published but tested less.
+  - Builds may show operating-system trust warnings until signing and notarization mature.
+  - The project is early and low-star, so evaluate it as a useful codebase rather than a popularity signal.
+source:
+  type: submit
+  provider: github
+  owner: Posnic
+  repo: POS
+  url: https://github.com/Posnic/POS
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep

--- a/data/taxonomy/stacks.yml
+++ b/data/taxonomy/stacks.yml
@@ -45,3 +45,9 @@
   family: web
   languages: [typescript, javascript]
   platforms: [web]
+
+- id: javascript
+  name: JavaScript
+  family: web
+  languages: [javascript]
+  platforms: [web, desktop]


### PR DESCRIPTION
## What this PR does

Adds **Posnic POS** to Open Apps as a business-category app and adds a short detail note for reviewers/readers.

Posnic is a JavaScript/Electron desktop POS and billing app for retail shops and restaurants, with offline-first checkout, inventory, reports, receipt printing, local backups, and public Windows/macOS/Linux releases.

This PR also adds a reusable `javascript` stack taxonomy entry because the catalog already has a JavaScript stack icon, but no existing stack accurately described a JavaScript/Electron desktop app.

## Why it belongs

- It is a usable application, not a library, boilerplate, tutorial, or one-screen demo.
- The source repository is public and licensed AGPL-3.0-only.
- The project has public release assets, user/self-hosting/hardware/release-verification docs, and explicit third-party package licensing caveats.
- Open-source POS/billing software is a useful business-app category for developers evaluating offline-first retail workflows.

## How to verify

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec grove icons sync --check`
- `corepack pnpm exec node --input-type=module -e "import { loadConfig, validateProject } from '@grove-dev/core'; const config = await loadConfig(); const result = await validateProject(config); if (!result.ok) process.exit(1); console.log('validateProject ok');"`
- `corepack pnpm run check`
- `corepack pnpm build`

Local note: on this Windows host, the combined `corepack pnpm exec grove check` command completed Grove validation/artifact preparation (`89 records prepared`) and then hit `spawn pnpm ENOENT` at the hardcoded child `pnpm exec astro check` step because the local shim is `pnpm.cmd`. I ran Grove validation and Astro check/build directly through Corepack instead.

## Disclosure

I am submitting this on behalf of the Posnic project.
