### PR TITLE
Add IPCamLapse

### DIFF
--- a/content/records/ipcamlapse.md
+++ b/content/records/ipcamlapse.md
@@ -1,0 +1,54 @@
+# IPCamLapse
+
+IPCamLapse is a local-first web application for turning periodic IP-camera snapshots into H.264 timelapse videos. It runs on Windows, Linux, or Docker and serves its interface over loopback by default. A built-in simulated camera makes the complete capture-to-video workflow usable without camera hardware.
+
+## What the codebase includes
+
+- An ASP.NET Core Razor Pages interface for sessions, camera profiles, storage settings, system checks, captured frames, and video controls.
+- A hosted capture service with explicit scheduled, capturing, paused, rendering, completed, failed, and cancelled states.
+- Fixed-timeline capture scheduling that skips missed slots instead of letting slow requests create cumulative drift.
+- HTTP camera requests with retries, exponential backoff, response-size limits, JPEG validation, and diagnostics.
+- Reusable camera profiles whose passwords are protected at rest with ASP.NET Core Data Protection.
+- An FFmpeg boundary for frame-range selection, scaling or cropping, frame rate, quality, elapsed-time overlays, and MP4 generation.
+- Storage estimates, actual usage, disk reserve, configurable limits, retention cleanup, and low-space warnings.
+- Self-contained Windows x64, Linux x64, and Linux ARM64 releases, plus Linux AMD64 and ARM64 container images with FFmpeg included.
+
+## Why it is useful to study
+
+The capture loop demonstrates two timing problems that are easy to miss in background services. Paused and out-of-window time is excluded from active capture duration, and each frame deadline advances from the planned timeline rather than from the end of the previous network request. The project uses `TimeProvider`-based tests for those rules so long-running behavior can be checked deterministically.
+
+The camera boundary is also deliberately narrow. Camera targets default to literal private, loopback, or link-local HTTP addresses; snapshot responses are size-bounded and accepted only after JPEG validation. The application documents the resulting security model instead of presenting a local service without authentication as safe for direct internet exposure.
+
+For end-to-end work, the demo camera exercises capture, persistence, gallery browsing, rendering, and video download without relying on a particular camera model. The integration suite drives that same path through the HTTP application.
+
+## Caveats
+
+IPCamLapse is an early-preview project with a small user and contributor base. Its real-camera input is an HTTP or HTTPS JPEG snapshot endpoint; it does not currently ingest RTSP streams. Native installs need a working FFmpeg executable for rendering, while the published container image includes FFmpeg.
+
+The web interface has no user authentication. The supported deployment is a trusted machine serving the UI over loopback. Remote access needs an authenticated TLS reverse proxy and a careful review of the documented forwarded-header and access-control assumptions.
+
+## How to run it
+
+Download the latest Windows or Linux archive, start the executable, open the local URL, and choose **Demo camera** to test the workflow. From source, the basic development path is:
+
+```console
+git clone https://github.com/KalyteraSystems/IPCamLapse.git
+cd IPCamLapse
+dotnet restore --locked-mode
+dotnet run --project IPCamLapse --urls http://127.0.0.1:5080
+```
+
+The published container can be run with a persistent data volume and a loopback-only host binding:
+
+```console
+docker run --detach --name ipcamlapse --publish 127.0.0.1:5080:8080 --env LocalAccess__AllowPrivateNetworks=true --volume ipcamlapse-data:/data ghcr.io/kalyterasystems/ipcamlapse:latest
+```
+
+## Verified sources
+
+- IPCamLapse repository: <https://github.com/KalyteraSystems/IPCamLapse>
+- Latest release: <https://github.com/KalyteraSystems/IPCamLapse/releases/latest>
+- Container image: <https://github.com/KalyteraSystems/IPCamLapse/pkgs/container/ipcamlapse>
+- Architecture: <https://github.com/KalyteraSystems/IPCamLapse/blob/main/docs/ARCHITECTURE.md>
+- Security policy: <https://github.com/KalyteraSystems/IPCamLapse/blob/main/SECURITY.md>
+- Contributor guide: <https://github.com/KalyteraSystems/IPCamLapse/blob/main/CONTRIBUTING.md>

--- a/data/records/ipcamlapse.yml
+++ b/data/records/ipcamlapse.yml
@@ -1,0 +1,122 @@
+kind: project
+name: IPCamLapse
+slug: ipcamlapse
+addedAt: 2026-09-04
+description: IPCamLapse is a self-hosted web app that captures JPEG snapshots from IP cameras on a
+  fixed schedule and renders them into H.264 timelapse videos with FFmpeg.
+summary: A local-first ASP.NET Core application for scheduled IP-camera capture, frame review,
+  storage controls, and H.264 rendering on Windows, Linux, or Docker.
+sourceDescription: Local-first .NET app that captures IP camera snapshots and creates H.264
+  timelapse videos with FFmpeg.
+content: ./content/records/ipcamlapse.md
+category: media
+tags:
+  - open-source
+  - self-hosted
+  - web-app
+  - privacy
+  - camera
+  - timelapse
+  - ffmpeg
+  - docker
+stack: aspnet-core
+platforms:
+  - web
+  - windows
+  - linux
+projectType: real-app
+repoUrl: https://github.com/KalyteraSystems/IPCamLapse
+links:
+  github: https://github.com/KalyteraSystems/IPCamLapse
+  website: https://kalyterasystems.com/OpenSource
+  docs: https://github.com/KalyteraSystems/IPCamLapse/tree/main/docs
+licenses:
+  - apache-2.0
+distribution:
+  channels:
+    - type: github-releases
+      label: Windows and Linux archives
+      url: https://github.com/KalyteraSystems/IPCamLapse/releases/latest
+      verified: true
+    - type: other
+      label: GHCR container image
+      url: https://github.com/KalyteraSystems/IPCamLapse/pkgs/container/ipcamlapse
+      verified: true
+bestFor:
+  - Turning periodic HTTP or HTTPS JPEG snapshots into local timelapse videos on a trusted machine.
+  - Trying a complete capture-to-video workflow without camera hardware by using the simulated
+    camera.
+  - Studying fixed-timeline scheduling, resilient HTTP capture, local persistence, and FFmpeg
+    integration in an ASP.NET Core application.
+whyListed:
+  - It is a complete, installable application with Windows and Linux releases and a
+    multi-architecture container image rather than a tutorial or example project.
+  - Demo mode makes the full capture, gallery, render, and download workflow testable without an IP
+    camera.
+  - The repository documents its security boundary and architecture and tests timing behavior and
+    the end-to-end capture-to-download path.
+caveats:
+  - The project is an early preview with a small user and contributor base.
+  - Camera input is limited to HTTP or HTTPS JPEG snapshot endpoints; RTSP streams are not supported.
+  - The web interface has no user authentication and should remain on loopback or behind an
+    authenticated reverse proxy.
+  - Native installations require FFmpeg for video rendering; the container image includes it.
+source:
+  type: submit
+  provider: github
+  owner: KalyteraSystems
+  repo: IPCamLapse
+  url: https://github.com/KalyteraSystems/IPCamLapse
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep
+health:
+  status: active
+  maturity: useful
+  tier: experimental
+  visibility: keep
+  cleanupCandidate: false
+  staleReason: null
+  confidence: high
+  reasons:
+    - Recent repository activity
+    - Recent release found
+    - Clear license found
+github:
+  repository:
+    full_name: KalyteraSystems/IPCamLapse
+    stargazers_count: 0
+    forks_count: 2
+    open_issues_count: 11
+    language: C#
+    pushed_at: 2026-09-04T11:54:20Z
+    updated_at: 2026-09-04T11:56:21Z
+    archived: false
+    disabled: false
+    default_branch: main
+    license:
+      spdx_id: Apache-2.0
+      name: Apache-2.0
+    topics:
+      - aspnet-core
+      - camera
+      - cctv
+      - docker
+      - dotnet
+      - ffmpeg
+      - ip-camera
+      - linux
+      - razor-pages
+      - security-cameras
+      - self-hosted
+      - surveillance
+      - timelapse
+      - timelapse-videos
+      - windows
+  latestReleaseAt: 2026-09-04T11:49:50Z
+  homepage: https://kalyterasystems.com/OpenSource
+  sync:
+    syncedAt: 2026-09-04T12:02:04.693Z
+    source: api

--- a/data/taxonomy/stacks.yml
+++ b/data/taxonomy/stacks.yml
@@ -51,3 +51,9 @@
   family: web
   languages: [javascript]
   platforms: [web, desktop]
+
+- id: aspnet-core
+  name: ASP.NET Core
+  family: web
+  languages: [csharp]
+  platforms: [web, windows, linux]


### PR DESCRIPTION
## What this PR does

Adds IPCamLapse, a local-first ASP.NET Core app that captures IP-camera JPEG snapshots and renders H.264 timelapse videos. It also adds an ASP.NET Core stack entry so the app can be classified accurately.

## Why it belongs

- It is a usable application with a hardware-free demo workflow, not a tutorial or library.
- It publishes self-contained Windows, Linux x64, and Linux ARM64 archives plus a multi-architecture container.
- The codebase includes deterministic timing tests and an integration test for capture, render, and download.
- Its listing is explicit that the project is new, supports JPEG snapshot endpoints rather than RTSP, and requires a trusted local deployment or authenticated reverse proxy.

I maintain IPCamLapse through Kalytera Systems.

## Verification

- Grove schema validation: 0 errors, 0 warnings.
- `pnpm exec astro check`: 0 errors (7 pre-existing informational hints).
- `pnpm build`: passed; generated `/apps/ipcamlapse/` and `/stacks/aspnet-core/`.
- All repository, release, package, documentation, and website links return HTTP 200.

On Windows, `pnpm exec grove check` completes Grove validation and preparation, then Grove 0.9.0 hits `spawn EINVAL` while launching `astro.cmd`. Running its Astro step directly passes; Linux CI can exercise the combined command.
