### PR TITLE
Add SubnetDesk

### DIFF
--- a/content/records/subnetdesk.md
+++ b/content/records/subnetdesk.md
@@ -1,0 +1,39 @@
+# SubnetDesk
+
+SubnetDesk is a cross-platform remote desktop application for devices that can already reach each
+other through the same LAN, a routed private network, or a VPN. It is derived from RustDesk but
+deliberately removes the public device-ID, rendezvous, relay, cloud-account, proxy, and automatic
+public-update paths. Users connect directly by IP address or hostname, while mDNS can discover
+nearby devices on a local network.
+
+## What makes it different
+
+The project is narrower than a general Internet remote-support service. It assumes that routing is
+already handled by the user's LAN or VPN and keeps the connection on that existing path. This makes
+it useful for home labs, offices, classrooms, and on-site support where public coordination is
+unnecessary or undesirable.
+
+SubnetDesk retains remote control, clipboard, audio, and file transfer. Its access controls include
+username/password authentication with Argon2id password hashes, trust-on-first-use endpoint
+fingerprints, and CIDR source-network allowlists. The codebase pairs a Rust systems core with a
+Flutter interface and ships for Windows, macOS, Linux, and Android.
+
+## Caveats
+
+SubnetDesk does not provide Internet rendezvous, NAT traversal, or a relay service. Both endpoints
+must already be mutually reachable through a LAN, private route, or VPN. Its listening port should
+only be exposed to trusted networks, and users should verify a new device fingerprint through a
+separate trusted channel when possible.
+
+## How to get it
+
+The latest GitHub release provides Windows MSI and portable executable builds, macOS disk images
+for Intel and Apple Silicon, Linux DEB, RPM, AppImage, Flatpak, and Arch packages, and Android APKs.
+
+## Verified sources
+
+- Repository: <https://github.com/zibo-chen/SubnetDesk>
+- Latest release: <https://github.com/zibo-chen/SubnetDesk/releases/latest>
+- Project scope and comparison: <https://github.com/zibo-chen/SubnetDesk#why-subnetdesk>
+- Security model: <https://github.com/zibo-chen/SubnetDesk#security-model>
+- Build instructions: <https://github.com/zibo-chen/SubnetDesk#build-from-source>

--- a/data/records/subnetdesk.yml
+++ b/data/records/subnetdesk.yml
@@ -1,0 +1,138 @@
+kind: project
+name: SubnetDesk
+slug: subnetdesk
+addedAt: 2026-09-05
+description: SubnetDesk is a cross-platform remote desktop for devices already connected by a LAN,
+  routed private network, or VPN, with direct IP or hostname connections and local mDNS discovery.
+summary: A Rust and Flutter remote-control app derived from RustDesk that deliberately removes
+  public device IDs, rendezvous, relays, cloud accounts, proxies, and public update paths in favor
+  of direct connections over an existing private network.
+sourceDescription: LAN-only remote desktop based on RustDesk.
+content: ./content/records/subnetdesk.md
+category: tools
+tags:
+  - remote-desktop
+  - remote-access
+  - remote-control
+  - lan
+  - vpn
+  - mdns
+  - privacy
+  - homelab
+  - self-hosted
+  - rust
+  - flutter
+  - desktop-app
+  - windows
+  - macos
+  - linux
+  - android
+stack: flutter
+platforms:
+  - windows
+  - macos
+  - linux
+  - android
+  - desktop
+projectType: real-app
+repoUrl: https://github.com/zibo-chen/SubnetDesk
+links:
+  github: https://github.com/zibo-chen/SubnetDesk
+  download: https://github.com/zibo-chen/SubnetDesk/releases/latest
+  documentation: https://github.com/zibo-chen/SubnetDesk#readme
+licenses:
+  - agpl-3.0
+distribution:
+  channels:
+    - type: github-releases
+      platform: windows
+      label: Windows MSI and portable executable
+      url: https://github.com/zibo-chen/SubnetDesk/releases/latest
+      verified: true
+    - type: github-releases
+      platform: macos
+      label: macOS disk images for Intel and Apple Silicon
+      url: https://github.com/zibo-chen/SubnetDesk/releases/latest
+      verified: true
+    - type: github-releases
+      platform: linux
+      label: Linux DEB, RPM, AppImage, Flatpak, and Arch packages
+      url: https://github.com/zibo-chen/SubnetDesk/releases/latest
+      verified: true
+    - type: github-releases
+      platform: android
+      label: Android APKs
+      url: https://github.com/zibo-chen/SubnetDesk/releases/latest
+      verified: true
+bestFor:
+  - Remote control between devices that are already reachable over a LAN or VPN.
+  - Home labs, offices, classrooms, and on-site support that do not need Internet rendezvous.
+  - Studying a Rust system core paired with a Flutter interface across desktop and mobile targets.
+whyListed:
+  - It is a complete AGPL-3.0 end-user application with installable releases for Windows, macOS,
+    Linux, and Android.
+  - >-
+    Its LAN/VPN-only scope is a distinct alternative to a typical RustDesk deployment: public
+    coordination and relay paths are removed rather than merely made optional.
+  - It combines mDNS discovery, direct endpoint connections, Argon2id password storage,
+    trust-on-first-use fingerprints, and CIDR source-network allowlists.
+caveats:
+  - It cannot connect devices across unrelated networks because it has no Internet rendezvous,
+    NAT traversal, or relay service; the devices must already be mutually reachable.
+  - Remote-control ports should only be exposed to trusted networks, and first-use fingerprints
+    should be verified through a separate trusted channel.
+source:
+  type: submit
+  provider: github
+  owner: zibo-chen
+  repo: SubnetDesk
+  url: https://github.com/zibo-chen/SubnetDesk
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep
+health:
+  status: active
+  maturity: useful
+  tier: listed
+  visibility: keep
+  cleanupCandidate: false
+  staleReason: null
+  confidence: high
+  reasons:
+    - Recent repository activity
+    - Active user adoption
+    - Recent release found
+    - Clear license found
+github:
+  repository:
+    full_name: zibo-chen/SubnetDesk
+    stargazers_count: 300
+    forks_count: 33
+    open_issues_count: 6
+    language: Rust
+    pushed_at: 2026-09-03T01:44:26Z
+    updated_at: 2026-09-05T09:36:39Z
+    archived: false
+    disabled: false
+    default_branch: master
+    license:
+      spdx_id: AGPL-3.0
+      name: GNU Affero General Public License v3.0
+    topics:
+      - flutter
+      - homelab
+      - lan
+      - mdns
+      - privacy
+      - remote-access
+      - remote-desktop
+      - rust
+      - self-hosted
+      - vpn
+  latestReleaseAt: 2026-08-27T16:33:43Z
+  homepage: null
+  sync:
+    syncedAt: 2026-09-05T09:36:39Z
+    source: api


### PR DESCRIPTION
## What this PR does

Adds SubnetDesk as a Tools record with a concise project page, platform/download metadata, verified GitHub metadata, and its LAN/VPN-only constraints.

## Why

SubnetDesk is a complete AGPL-3.0 remote desktop application with public releases for Windows, macOS, Linux, and Android. Unlike the existing RustDesk record, it deliberately removes public rendezvous and relay paths for devices already connected through a LAN or VPN.

## How to verify

1. `pnpm install`
2. `pnpm exec grove check --strict`
3. `pnpm run build`
4. Open `/apps/subnetdesk/` and confirm the record, links, platforms, and caveats.

## Checklist

- [x] `pnpm exec grove check --strict` passes
- [x] `pnpm run build` succeeds locally
- [x] The `subnetdesk` slug is unique and matches `data/records/subnetdesk.yml`
- [x] No new categories, stacks, or platforms are introduced