### PR TITLE
Correct Posnic website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ request — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - [Invoice Ninja](https://invoiceninja.com/) - Companion app for the Invoice Ninja platform. Invoicing, expenses, time-billing, payments.
 - [Mise](https://devshakib.jumyn.com/apps/mise) - Mise is a self-hosted restaurant system for macOS that runs a till, a kitchen display, QR table ordering, and a back office from one machine on the restaurant's own network.
-- [Posnic POS](https://posnic.io/) - Posnic POS is offline-first open-source POS and billing software for retail shops and restaurants, built as a JavaScript/Electron desktop app with a local MongoDB-backed checkout.
+- [Posnic POS](https://www.posnic.com/) - Posnic POS is offline-first open-source POS and billing software for retail shops and restaurants, built as a JavaScript/Electron desktop app with a local MongoDB-backed checkout.
 - [Twenty](https://twenty.com) - Twenty is an open-source CRM whose data model is a runtime artifact — every custom object, field, view, role, and AI agent is a row in metadata tables, with the GraphQL schema and SQL queries rebuilt per workspace on demand. Written in TypeScript with NestJS, React, PostgreSQL, and a native MCP server for Claude/ChatGPT/Cursor.
 
 ## Games

--- a/content/records/posnic-pos.md
+++ b/content/records/posnic-pos.md
@@ -39,7 +39,7 @@ The development app downloads and runs its local database during setup. For pack
 ## Verified sources
 
 - Posnic POS repository: <https://github.com/Posnic/POS>
-- Posnic website: <https://posnic.io/>
+- Posnic website: <https://www.posnic.com/>
 - Latest release: <https://github.com/Posnic/POS/releases/tag/v1.6.1>
 - User guide: <https://github.com/Posnic/POS/blob/develop/docs/USER_GUIDE.md>
 - Self-hosting guide: <https://github.com/Posnic/POS/blob/develop/docs/SELF_HOSTING.md>

--- a/data/records/posnic-pos.yml
+++ b/data/records/posnic-pos.yml
@@ -36,7 +36,7 @@ projectType: real-app
 repoUrl: https://github.com/Posnic/POS
 links:
   github: https://github.com/Posnic/POS
-  website: https://posnic.io/
+  website: https://www.posnic.com/
   docs: https://github.com/Posnic/POS/tree/develop/docs
 licenses:
   - agpl-3.0
@@ -139,7 +139,7 @@ github:
       - retail-pos
       - windows
   latestReleaseAt: 2026-08-28T04:45:42Z
-  homepage: https://posnic.io/
+  homepage: https://www.posnic.com/
   sync:
     syncedAt: 2026-09-07T04:04:18.066Z
     source: api


### PR DESCRIPTION
Updates the Posnic listing to use the correct official website, https://www.posnic.com/, while preserving its open-source POS description and GitHub repository link.