### PR TITLE
Fix Posnic canonical homepage metadata

### DIFF
--- a/data/records/posnic-pos.yml
+++ b/data/records/posnic-pos.yml
@@ -139,7 +139,7 @@ github:
       - retail-pos
       - windows
   latestReleaseAt: 2026-08-28T04:45:42Z
-  homepage: https://posnic.io/
+  homepage: https://www.posnic.com/
   sync:
     syncedAt: 2026-09-10T10:03:18.374Z
     source: api


### PR DESCRIPTION
## Summary

Corrects the synced Posnic homepage metadata from the retired domain to the canonical website:

- `https://www.posnic.com/`

The manually curated website field already uses the canonical URL; this keeps the GitHub metadata field consistent.

## Validation

- `git diff --check`