### PR TITLE
Remove stale Posnic release trust warning

### DIFF
--- a/data/records/posnic-pos.yml
+++ b/data/records/posnic-pos.yml
@@ -76,7 +76,6 @@ caveats:
     components including MongoDB Community Server under SSPL-1.0.
   - Windows is the best-tested retail-hardware target; macOS and Linux builds are published but
     tested less.
-  - Builds may show operating-system trust warnings until signing and notarization mature.
   - The project is early and low-star, so evaluate it as a useful codebase rather than a popularity
     signal.
 source:


### PR DESCRIPTION
## Summary

Removes the stale caveat that Posnic builds may show operating-system trust warnings until signing and notarization mature.

The current stable v1.6.1 release states that:

- Windows installers are signed and timestamped
- macOS packages are signed, notarized, and have the ticket stapled
- Linux packages have checksums and detached GPG signatures, with a signed APT channel

Official evidence: https://github.com/Posnic/POS/releases/tag/v1.6.1

The remaining caveats about hardware testing, component licensing, and project maturity are unchanged.

## Validation

- pnpm build passed and rendered /apps/posnic-pos/
- pnpm exec grove check reaches validation but reports the pre-existing unrelated missing_health: subnetdesk error
- git diff --check passed

I am affiliated with Posnic and prepared this factual correction with automation assistance.