### PR TITLE
Add OpenPost social publishing app

### DIFF
--- a/data/records/openpost.yml
+++ b/data/records/openpost.yml
@@ -1,0 +1,56 @@
+kind: project
+name: OpenPost
+slug: openpost
+addedAt: 2026-09-12
+description: Self-hosted social publishing app for preparing, reviewing, scheduling, and tracking posts across several networks.
+category: business
+tags:
+  - content-creation
+  - docker-compose
+  - go
+  - mcp-server
+  - self-hosted
+  - social-media-management
+  - sveltekit
+stack: svelte
+platforms:
+  - web
+projectType: real-app
+repoUrl: https://github.com/getopenpost/openpost
+links:
+  github: https://github.com/getopenpost/openpost
+  website: https://openpo.st
+  docs: https://docs.openpo.st
+licenses:
+  - agpl-3.0
+bestFor:
+  - Running a social publishing workflow on your own server.
+  - Studying a SvelteKit app embedded in a Go server with SQLite by default.
+whyListed:
+  - A usable web app with public releases, self-hosting instructions, and source under the AGPL-3.0 license.
+  - Its Go server embeds the SvelteKit interface and exposes an API, CLI, and MCP server.
+caveats:
+  - Connecting social accounts requires provider OAuth configuration when self-hosted.
+source:
+  type: submit
+  provider: github
+  owner: getopenpost
+  repo: openpost
+  url: https://github.com/getopenpost/openpost
+curation:
+  reviewed: false
+  labels: []
+  lenses: []
+visibility: keep
+health:
+  status: active
+  maturity: useful
+  tier: listed
+  visibility: keep
+  cleanupCandidate: false
+  staleReason: null
+  confidence: high
+  reasons:
+    - Recent repository activity
+    - Recent release found
+    - Clear license found

--- a/data/taxonomy/stacks.yml
+++ b/data/taxonomy/stacks.yml
@@ -46,6 +46,12 @@
   languages: [typescript, javascript]
   platforms: [web]
 
+- id: svelte
+  name: Svelte (web)
+  family: web
+  languages: [typescript, javascript]
+  platforms: [web]
+
 - id: javascript
   name: JavaScript
   family: web


### PR DESCRIPTION
OpenPost is a usable AGPL-3.0 web app with public releases and a Docker Compose setup. The record lists its Go/SvelteKit stack, the self-hosting caveat for provider OAuth, and links to the repository and docs. I added a Svelte web stack value because the existing options are React, JavaScript, and mobile or desktop frameworks; labeling this TypeScript SvelteKit interface as React or plain JavaScript would be inaccurate.

Validated with `pnpm exec grove check` and `pnpm build`. The checks passed; Astro reported only existing hints. This is a self-submission.